### PR TITLE
Sorting across different datatypes

### DIFF
--- a/src/TupleTools.jl
+++ b/src/TupleTools.jl
@@ -250,7 +250,8 @@ end
 _sort(t::Tuple{Any}, lt=isless, by=identity, rev::Bool=false) = t
 _sort(t::Tuple{}, lt=isless, by=identity, rev::Bool=false) = t
 
-function _split(t::NTuple{N}) where N
+function _split(t::Tuple)
+    N = length(t)
     M = N>>1
     ntuple(i->t[i], M), ntuple(i->t[i+M], N-M)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -78,4 +78,4 @@ end
 @test @inferred(TupleTools.diff((1, ))) == ()
 @test @inferred(TupleTools.diff((1, 2, 3))) == (1, 1)
 
-@test TupleTools.sort(2,1,3.0) === (1,2,3.0)
+@test TupleTools.sort((2,1,3.0)) === (1,2,3.0)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -77,3 +77,5 @@ end
 @test @inferred(TupleTools.diff(())) == ()
 @test @inferred(TupleTools.diff((1, ))) == ()
 @test @inferred(TupleTools.diff((1, 2, 3))) == (1, 1)
+
+@test TupleTools.sort(2,1,3.0) === (1,2,3.0)


### PR DESCRIPTION
Before this PR:
```julia
julia> a,b,c = 2,1,3
(2, 1, 3)

julia> @btime TupleTools.sort((a,b,c))
  232.982 ns (2 allocations: 64 bytes)
(1, 2, 3)

julia> TupleTools.sort((2,1.0))
ERROR: MethodError: no method matching _split(::Tuple{Int64, Float64})

Closest candidates are:
  _split(::Tuple{Vararg{T, N}} where T) where N
   @ TupleTools C:\Users\pty\.julia\packages\TupleTools\ecrzx\src\TupleTools.jl:253

Stacktrace:
 [1] _sort
   @ C:\Users\pty\.julia\packages\TupleTools\ecrzx\src\TupleTools.jl:245 [inlined]
 [2] sort(t::Tuple{Int64, Float64}; lt::Function, by::Function, rev::Bool)
   @ TupleTools C:\Users\pty\.julia\packages\TupleTools\ecrzx\src\TupleTools.jl:243
 [3] sort(t::Tuple{Int64, Float64})
   @ TupleTools C:\Users\pty\.julia\packages\TupleTools\ecrzx\src\TupleTools.jl:243
 [4] top-level scope
   @ REPL[40]:1
```

After this PR:
```julia
julia> @btime TupleTools.sort((a,b,c))
  247.842 ns (2 allocations: 64 bytes)
(1, 2, 3)

julia> c = 3.0
3.0

julia> @btime TupleTools.sort((a,b,c))
  752.857 ns (5 allocations: 128 bytes)
(1, 2, 3.0)

julia> @btime TupleTools.sort((2.0,1.0,c))
  258.457 ns (2 allocations: 64 bytes)
(1.0, 2.0, 3.0)
```