### PR TITLE
Small updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,9 @@ jobs:
         env:
           JULIA_NUM_THREADS: 4
       - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v3
+      - uses: codecov/codecov-action@v4
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
           file: lcov.info
   test-nightly:

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TupleTools"
 uuid = "9d95972d-f1c8-5527-a6e0-b4b365fa01f6"
 authors = ["Jutho Haegeman"]
-version = "1.4.3"
+version = "1.5.0"
 
 [deps]
 

--- a/Project.toml
+++ b/Project.toml
@@ -7,6 +7,9 @@ version = "1.4.3"
 
 [compat]
 julia = "1"
+Aqua = "0.8"
+Random = "1"
+Test = "1"
 
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"

--- a/src/TupleTools.jl
+++ b/src/TupleTools.jl
@@ -317,6 +317,15 @@ _permute(t::NTuple{N,Any}, p::NTuple{N,Int}) where {N} = getindices(t, p)
 _permute(t::NTuple{N,Any}, p) where {N} = ntuple(n -> t[p[n]], StaticLength(N))
 
 """
+    circshift(t::NTuple{N,Any}, i::Int) -> ::NTuple{N,Any}
+
+Circularly shift the elements of tuple `t` by `i` positions.
+"""
+function circshift(t::NTuple{N,Any}, i::Int) where {N}
+    return ntuple(n -> t[mod1(n - i, N)], StaticLength(N))
+end
+
+"""
     isperm(p) -> ::Bool
 
 A non-allocating alternative to Base.isperm(p) that is much faster for small permutations.

--- a/src/TupleTools.jl
+++ b/src/TupleTools.jl
@@ -382,4 +382,14 @@ diff(v::Tuple{}) = () # similar to diff([])
 diff(v::Tuple{Any}) = ()
 diff(v::Tuple) = (v[2] - v[1], diff(Base.tail(v))...)
 
+"""
+    indexin(a::Tuple, b::Tuple)
+
+Return a tuple containing the first indices in `b` of the elements of `a`. If an element
+of `a` is not in `b`, then the corresponding index will be `nothing`.
+"""
+function indexin(a::Tuple, b::Tuple)
+    return ntuple(i -> findfirst(==(a[i]), b), length(a))
+end
+
 end # module

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -78,6 +78,7 @@ using Base: tail, front
     @test @inferred(TupleTools.isperm(t)) == true
     @test @inferred(TupleTools.isperm((1, 2, 1))) == false
     @test @inferred(TupleTools.permute(t, t)) == (p[p]...,)
+    @test @inferred(TupleTools.circshift(t, 3)) == tuple(circshift(p, 3)...,)
 
     @test @inferred(TupleTools.vcat()) == ()
     @test @inferred(TupleTools.diff(())) == ()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -78,7 +78,7 @@ using Base: tail, front
     @test @inferred(TupleTools.isperm(t)) == true
     @test @inferred(TupleTools.isperm((1, 2, 1))) == false
     @test @inferred(TupleTools.permute(t, t)) == (p[p]...,)
-    @test @inferred(TupleTools.circshift(t, 3)) == tuple(circshift(p, 3)...,)
+    @test @inferred(TupleTools.circshift(t, 3)) == tuple(circshift(p, 3)...)
 
     @test @inferred(TupleTools.vcat()) == ()
     @test @inferred(TupleTools.diff(())) == ()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -90,6 +90,5 @@ end
 @testset "TupleTools quality assurance with Aqua" begin
     using Aqua
     Aqua.test_all(TupleTools;
-                  project_toml_formatting=(VERSION >= v"1.9"),
                   unbound_args=false)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -86,6 +86,7 @@ using Base: tail, front
     @test @inferred(TupleTools.diff((1, 2, 3))) == (1, 1)
 
     @test TupleTools.sort((2, 1, 3.0)) === (1, 2, 3.0)
+    @test TupleTools.indexin(TupleTools.getindices(t, (1, 2, 3)), t) == (1, 2, 3)
 end
 
 @testset "TupleTools quality assurance with Aqua" begin


### PR DESCRIPTION
This PR adds some functions that were previously missing, such as `circshift` and `indexin`.

As a small note, for the implementation of `indexin`, for large tuples an implementation via a hash map would be more efficient $\mathcal{O}(N)$, but as this package focusses on small tuples, I choose to use a simple $\mathcal{O}(N^2)$ algorithm, which is non-allocating. (I think)

Also, it updates the codecov action, and Aqua tests to reflect the latest versions.
It also adds compat entries for the test dependencies.