### PR TITLE
Remove unnecessary imports

### DIFF
--- a/src/TupleTools.jl
+++ b/src/TupleTools.jl
@@ -3,7 +3,7 @@ Type stable methods for small tuples
 """
 module TupleTools
 
-using Base: tuple_type_head, tuple_type_tail, tuple_type_cons, tail, front, setindex
+using Base: tail, front
 
 """
     struct StaticLength{N} end


### PR DESCRIPTION
`tuple_type_head, tuple_type_tail, tuple_type_cons, setindex` are imported, but unused in the code.